### PR TITLE
Changed category number

### DIFF
--- a/D_LiveHouseFan1.xml
+++ b/D_LiveHouseFan1.xml
@@ -15,8 +15,8 @@
 		<modelName>LiveHouseFan</modelName>
 		<protocol>cr</protocol>
 		<handleChildren>0</handleChildren>
-		<Category_Num>5</Category_Num>
-		<Subcategory_Num>3</Subcategory_Num>
+		<Category_Num>666</Category_Num>
+		<Subcategory_Num></Subcategory_Num>
 		<serviceList>
 			<service>
 				<serviceType>urn:schemas-livehouse-automation:service:LiveHouseFan:1</serviceType>


### PR DESCRIPTION
Using 666 as an undefined/custom number. Works for other plugins to render correctly in Vera Mobile App

Fixes #1 